### PR TITLE
Revert node-fetch

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "feed": "^2.0.1",
     "jsdom": "^16.4.0",
-    "node-fetch": "^2.6.1",
+    "node-fetch": "= 2.6.0",
     "source-map-support": "^0.5.19"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5996,6 +5996,11 @@ node-dir@^0.1.17:
   dependencies:
     minimatch "^3.0.2"
 
+"node-fetch@= 2.6.0":
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
+  integrity sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==
+
 node-fetch@^1.0.1:
   version "1.7.3"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
@@ -6004,7 +6009,7 @@ node-fetch@^1.0.1:
     encoding "^0.1.11"
     is-stream "^1.0.1"
 
-node-fetch@^2.6.0, node-fetch@^2.6.1:
+node-fetch@^2.6.0:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==


### PR DESCRIPTION
To solve this error

```
ERROR	Uncaught Exception 	{     "errorType": "TypeError",     "errorMessage": "The \"id\" argument must be of type string. Received undefined",     "code": "ERR_INVALID_ARG_TYPE",     "stack": [         "TypeError [ERR_INVALID_ARG_TYPE]: The \"id\" argument must be of type string. Received undefined",         "    at validateString (internal/validators.js:120:11)",         "    at Module.require (internal/modules/cjs/loader.js:1018:3)",         "    at require (internal/modules/cjs/helpers.js:72:18)",         "    at Object.<anonymous> (/var/task/src/handler.js:151:84545)",         "    at r (/var/task/src/handler.js:1:158)",         "    at Object.<anonymous> (/var/task/src/handler.js:1:43784)",         "    at r (/var/task/src/handler.js:1:158)",         "    at Object.<anonymous> (/var/task/src/handler.js:337:388014)",         "    at r (/var/task/src/handler.js:1:158)",         "    at Object.<anonymous> (/var/task/src/handler.js:151:70258)"     ] } | 2020-09-24T16:07:43.481Z undefined ERROR Uncaught Exception {"errorType":"TypeError","errorMessage":"The \"id\" argument must be of type string. Received undefined","code":"ERR_INVALID_ARG_TYPE","stack":["TypeError [ERR_INVALID_ARG_TYPE]: The \"id\" argument must be of type string. Received undefined"," at validateString (internal/validators.js:120:11)"," at Module.require (internal/modules/cjs/loader.js:1018:3)"," at require (internal/modules/cjs/helpers.js:72:18)"," at Object.<anonymous> (/var/task/src/handler.js:151:84545)"," at r (/var/task/src/handler.js:1:158)"," at Object.<anonymous> (/var/task/src/handler.js:1:43784)"," at r (/var/task/src/handler.js:1:158)"," at Object.<anonymous> (/var/task/src/handler.js:337:388014)"," at r (/var/task/src/handler.js:1:158)"," at Object.<anonymous> (/var/task/src/handler.js:151:70258)"]}
```